### PR TITLE
fix chargeTimeBasedFees

### DIFF
--- a/src/core.mo
+++ b/src/core.mo
@@ -270,7 +270,8 @@ module {
             let now = Nat64.toNat(nowU64);
             label vloop for ((vid, vec) in entries()) {
                 if (vec.billing.expires != null) continue vloop; // Not charging temp nodes
-
+                if (vec.meta.billing.cost_per_day == 0) continue vloop;
+                
                 let billing = vec.meta.billing;
                 let billing_subaccount = ?U.port2subaccount({
                     vid;


### PR DESCRIPTION
The `chargeTimeBasedFees` function runs a loop with this in it:

`let days_left = (current_billing_balance - fee_to_charge : Nat) / billing.cost_per_day;`

- When `cost_per_day` is 0, it was causing a division by 0 trap and not processing the rest of the nodes.
- By returning early we fix that and make the loop a little bit more efficient.